### PR TITLE
Removes carriage return from textarea that causes weird spacing on input

### DIFF
--- a/step07.md
+++ b/step07.md
@@ -29,9 +29,7 @@ Open up the `index.html` file in your text editor.  If you have a look, you shou
 ```html
 <h3>Create a blog post</h3>
 <form action="/create-post" method="POST">
-    <textarea name="blogpost" rows="10" cols="14">
-
-    </textarea>
+    <textarea name="blogpost" rows="10" cols="14"></textarea>
     <button type="submit">Send</button>
 </form>
 ```


### PR DESCRIPTION
As per :arrow_up:

Turns out this is just in the instructions and not in the final code.
